### PR TITLE
add ability to use cache for include node evaluations

### DIFF
--- a/expr/node.go
+++ b/expr/node.go
@@ -136,7 +136,11 @@ type (
 		ContextReader
 		Includer
 	}
-
+	// IncludeCacheContext used to cache results of include node evaluations
+	IncludeCacheContext interface {
+		GetCachedResult(name string) (bool, bool, error)
+		SetCache(name string, matches, ok bool)
+	}
 	// ContextReader is a key-value interface to read the context of message/row
 	// using a  Get("key") interface.  Used by vm to evaluate messages
 	ContextReader interface {


### PR DESCRIPTION
This should boost performance in situations where several filters
with overlapping includes are evaluated for a given entity. It also
uses the cache for filter statements with alias.