### PR TITLE
check for empty alias in filter statement

### DIFF
--- a/vm/filterqlvm.go
+++ b/vm/filterqlvm.go
@@ -82,7 +82,7 @@ func MatchesInc(inc expr.Includer, cr expr.EvalContext, stmt *rel.FilterStatemen
 // returning true if the context matches.
 func Matches(cr expr.EvalContext, stmt *rel.FilterStatement) (bool, bool) {
 	cacheCtx, hasCache := cr.(expr.IncludeCacheContext)
-	if hasCache {
+	if hasCache && stmt.Alias != "" {
 		matches, ok, err := cacheCtx.GetCachedResult(strings.ToLower(stmt.Alias))
 		if err == nil {
 			return matches, ok


### PR DESCRIPTION
It should not be possible that the cache contains an entry for an empty string, but to be on the safe side we should check here once again.