### PR TITLE
do not look up cache by alias

### DIFF
--- a/expr/node.go
+++ b/expr/node.go
@@ -138,7 +138,10 @@ type (
 	}
 	// IncludeCacheContext used to cache results of include node evaluations
 	IncludeCacheContext interface {
+		// GetCachedResult returns cached values for matches and ok as the first two return values respectively
+		// and returns an error in the case of a cache miss
 		GetCachedResult(name string) (bool, bool, error)
+		// SetCache stores matches and ok under the provided identifier name
 		SetCache(name string, matches, ok bool)
 	}
 	// ContextReader is a key-value interface to read the context of message/row

--- a/vm/filterqlvm_test.go
+++ b/vm/filterqlvm_test.go
@@ -357,7 +357,6 @@ func TestIncludeCache(t *testing.T) {
 
 	q1, err := rel.ParseFilterQL("FILTER INCLUDE cached_include")
 	q2, err := rel.ParseFilterQL("FILTER INCLUDE test")
-	q3, err := rel.ParseFilterQL("FILTER EXISTS does_not_matter_because_cached ALIAS cached_include ")
 	assert.Equal(t, nil, err)
 	{
 		ctx := &contextWithCache{EvalContext: e}
@@ -377,15 +376,6 @@ func TestIncludeCache(t *testing.T) {
 		assert.False(t, ctx.CachedResultUsed)
 		assert.True(t, ctx.SetCacheCalled)
 		assert.True(t, ctx.IncludeCalled)
-	}
-	{
-		ctx := &contextWithCache{EvalContext: e}
-		match, ok := vm.Matches(ctx, q3)
-		assert.True(t, ok)
-		assert.True(t, match)
-		assert.True(t, ctx.CachedResultUsed)
-		assert.False(t, ctx.SetCacheCalled)
-		assert.False(t, ctx.IncludeCalled)
 	}
 }
 


### PR DESCRIPTION
Because we now look up cached data using segment information in qlbridge client code, this cache lookup is redundant.