### PR TITLE
Update check for start token to check for multiply token

### DIFF
--- a/expr/parse.go
+++ b/expr/parse.go
@@ -169,8 +169,7 @@ func newTreeFuncs(pager TokenPager, fr FuncResolver) *tree {
 
 // ParseExpression parse a single Expression, returning an Expression Node
 //
-//    ParseExpression("5 * toint(item_name)")
-//
+//	ParseExpression("5 * toint(item_name)")
 func ParseExpression(expressionText string) (Node, error) {
 	l := lex.NewLexer(expressionText, lex.LogicalExpressionDialect)
 	pager := NewLexTokenPager(l)
@@ -183,8 +182,7 @@ func ParseExpression(expressionText string) (Node, error) {
 // MustParse parse a single Expression, returning an Expression Node
 // and panics if it cannot be parsed
 //
-//    MustParse("5 * toint(item_name)")
-//
+//	MustParse("5 * toint(item_name)")
 func MustParse(expressionText string) Node {
 	n, err := ParseExpression(expressionText)
 	if err != nil {
@@ -197,8 +195,7 @@ func MustParse(expressionText string) Node {
 //
 // @fr = function registry with any additional functions
 //
-//    ParseExprWithFuncs("5 * toint(item_name)", funcRegistry)
-//
+//	ParseExprWithFuncs("5 * toint(item_name)", funcRegistry)
 func ParseExprWithFuncs(p TokenPager, fr FuncResolver) (Node, error) {
 	t := newTreeFuncs(p, fr)
 	// Parser panics on unexpected syntax, convert this into an err
@@ -616,7 +613,7 @@ func (t *tree) v(depth int) Node {
 	case lex.TokenNull:
 		t.Next()
 		return NewNull(cur)
-	case lex.TokenStar:
+	case lex.TokenStar, lex.TokenMultiply:
 		n := NewStringNoQuoteNode(cur.V)
 		t.Next()
 		return n
@@ -814,8 +811,9 @@ func (t *tree) ArrayNode(depth int) Node {
 }
 
 // ValueArray
-//     IN ("a","b","c")
-//     ["a","b","c"]
+//
+//	IN ("a","b","c")
+//	["a","b","c"]
 func ValueArray(depth int, pg TokenPager) (value.Value, error) {
 
 	vals := make([]value.Value, 0)

--- a/expr/parse.go
+++ b/expr/parse.go
@@ -613,6 +613,7 @@ func (t *tree) v(depth int) Node {
 	case lex.TokenNull:
 		t.Next()
 		return NewNull(cur)
+	// This really should be only TokenStar, but the lexer emits TokenMultiply as of (3.16.23).
 	case lex.TokenStar, lex.TokenMultiply:
 		n := NewStringNoQuoteNode(cur.V)
 		t.Next()

--- a/lex/lexer.go
+++ b/lex/lexer.go
@@ -1324,7 +1324,6 @@ func LexListOfArgs(l *Lexer) StateFn {
 
 	r := l.Next()
 	//u.Debugf("in LexListOfArgs:  '%s'", string(r))
-
 	switch r {
 	case ')':
 		//l.Emit(TokenRightParenthesis)
@@ -1341,10 +1340,9 @@ func LexListOfArgs(l *Lexer) StateFn {
 		if &l.lastToken != nil && l.lastToken.T == TokenLeftParenthesis {
 			l.Emit(TokenStar)
 			return nil
-		} else {
-			l.backup()
-			return LexExpression
 		}
+		l.backup()
+		return LexExpression
 	case '!', '=', '>', '<', '-', '+', '%', '&', '/', '|':
 		l.backup()
 		return LexExpression
@@ -1369,7 +1367,6 @@ func LexListOfArgs(l *Lexer) StateFn {
 			//u.Warnf("found keyword while looking for arg? %v", string(r))
 			return nil
 		}
-
 		//u.Debugf("LexListOfArgs sending LexExpressionOrIdentity: %v", string(peekWord))
 		l.Push("LexListOfArgs", LexListOfArgs)
 		return LexExpressionOrIdentity


### PR DESCRIPTION
see [this issue](https://github.com/lytics/lio/issues/30712). The parser wasn't recognizing the "*" in a filter ql statement. This is because the lexer emits a `TokenMultiply` but the parser was looking for a `TokenStar`. I've updated the parser to also check for a `TokenMultiply`. 