### PR TITLE
add optimization package

### DIFF
--- a/optimization/optimization.go
+++ b/optimization/optimization.go
@@ -1,0 +1,125 @@
+package optimization
+
+import (
+	"sort"
+
+	"github.com/lytics/qlbridge/expr"
+	"github.com/lytics/qlbridge/vm"
+)
+
+// SharedIncludedNodes stores nodes of already optimized included subtrees.
+// Its main purpose is to reduce memory usage of optimized expression trees by sharing these nodes.
+type SharedIncludedNodes struct {
+	data map[string]*nodeWithNumberOfChildren
+}
+
+func NewSharedIncludedNodes() *SharedIncludedNodes {
+	return &SharedIncludedNodes{
+		data: make(map[string]*nodeWithNumberOfChildren),
+	}
+}
+
+type nodeWithNumberOfChildren struct {
+	numberOfChildren uint64
+	node             expr.Node
+}
+
+// OptimizeBooleanNodes optimizes boolean nodes in the expression tree by sorting their arguments by number of children.
+// It returns an optimized deep-copy of the expression tree in order not to violate the immutability of expression trees.
+func OptimizeBooleanNodes(ctx expr.Includer, arg expr.Node, sharedIncludedNodes *SharedIncludedNodes) (expr.Node, error) {
+	npb := arg.NodePb()
+	newNode := expr.NodeFromNodePb(npb)
+	_, err := optimizeBooleanNodesDepth(ctx, newNode, 0, sharedIncludedNodes)
+	return newNode, err
+}
+
+func optimizeBooleanNodesDepth(ctx expr.Includer, arg expr.Node, depth int, sharedIncludedNodes *SharedIncludedNodes) (uint64, error) {
+	if depth > vm.MaxDepth {
+		return 0, vm.ErrMaxDepth
+	}
+	result := uint64(1)
+	switch n := arg.(type) {
+	case *expr.BooleanNode:
+		nodes := make([]nodeWithNumberOfChildren, len(n.Args))
+		for i, narg := range n.Args {
+			subTreeResult, err := optimizeBooleanNodesDepth(ctx, narg, depth+1, sharedIncludedNodes)
+			if err != nil {
+				return 0, err
+			}
+			result += subTreeResult
+			nodes[i] = nodeWithNumberOfChildren{
+				numberOfChildren: subTreeResult,
+				node:             narg,
+			}
+		}
+		sort.Slice(nodes, func(i, j int) bool {
+			return nodes[i].numberOfChildren < nodes[j].numberOfChildren
+		})
+		for i, node := range nodes {
+			n.Args[i] = node.node
+		}
+	case *expr.BinaryNode:
+		for _, narg := range n.Args {
+			subTreeResult, err := optimizeBooleanNodesDepth(ctx, narg, depth+1, sharedIncludedNodes)
+			if err != nil {
+				return 0, err
+			}
+			result += subTreeResult
+		}
+	case *expr.UnaryNode:
+		subTreeResult, err := optimizeBooleanNodesDepth(ctx, n.Arg, depth+1, sharedIncludedNodes)
+		if err != nil {
+			return 0, err
+		}
+		result += subTreeResult
+	case *expr.TriNode:
+		for _, narg := range n.Args {
+			subTreeResult, err := optimizeBooleanNodesDepth(ctx, narg, depth+1, sharedIncludedNodes)
+			if err != nil {
+				return 0, err
+			}
+			result += subTreeResult
+		}
+	case *expr.ArrayNode:
+		for _, narg := range n.Args {
+			subTreeResult, err := optimizeBooleanNodesDepth(ctx, narg, depth+1, sharedIncludedNodes)
+			if err != nil {
+				return 0, err
+			}
+			result += subTreeResult
+		}
+	case *expr.FuncNode:
+		for _, narg := range n.Args {
+			subTreeResult, err := optimizeBooleanNodesDepth(ctx, narg, depth+1, sharedIncludedNodes)
+			if err != nil {
+				return 0, err
+			}
+			result += subTreeResult
+		}
+	case *expr.IncludeNode:
+		if sharedNode, ok := sharedIncludedNodes.data[n.Identity.Text]; ok {
+			n.ExprNode = sharedNode.node
+			result += sharedNode.numberOfChildren
+		} else {
+			incExpr, err := ctx.Include(n.Identity.Text)
+			if err != nil {
+				return 0, err
+			}
+			if incExpr == nil {
+				return 0, expr.ErrIncludeNotFound
+			}
+			npb := incExpr.NodePb()
+			n.ExprNode = expr.NodeFromNodePb(npb)
+			subTreeResult, err := optimizeBooleanNodesDepth(ctx, n.ExprNode, depth+1, sharedIncludedNodes)
+			if err != nil {
+				return 0, err
+			}
+			sharedIncludedNodes.data[n.Identity.Text] = &nodeWithNumberOfChildren{
+				numberOfChildren: subTreeResult,
+				node:             n.ExprNode,
+			}
+			result += subTreeResult
+		}
+	}
+	return result, nil
+}

--- a/optimization/optimization_test.go
+++ b/optimization/optimization_test.go
@@ -1,0 +1,83 @@
+package optimization_test
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/lytics/qlbridge/datasource"
+	"github.com/lytics/qlbridge/expr"
+	"github.com/lytics/qlbridge/optimization"
+	"github.com/lytics/qlbridge/rel"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type includectx struct {
+	expr.ContextReader
+	filters map[string]*rel.FilterStatement
+}
+
+func newIncluderCtx(cr expr.ContextReader, statements string) *includectx {
+	stmts := rel.MustParseFilters(statements)
+	filters := make(map[string]*rel.FilterStatement, len(stmts))
+	for _, stmt := range stmts {
+		filters[strings.ToLower(stmt.Alias)] = stmt
+	}
+	return &includectx{ContextReader: cr, filters: filters}
+}
+func (m *includectx) Include(name string) (expr.Node, error) {
+	if filter, ok := m.filters[strings.ToLower(name)]; ok {
+		return filter.Filter, nil
+	}
+	return nil, expr.ErrNoIncluder
+}
+
+func TestOptimizeBooleanNodes(t *testing.T) {
+	nc := datasource.NewNestedContextReader([]expr.ContextReader{}, time.Now())
+	ctx := newIncluderCtx(nc,
+		`FILTER AND (
+						OR (
+							zip BETWEEN 1 AND 3
+							city == "Peoria, IL"
+						)
+						*
+					) ALIAS A;
+			`)
+	node, err := expr.ParseExpression(`AND (INCLUDE A, zip IN (1, 2, 3), city == "Peoria, IL", NOT true)`)
+	require.NoError(t, err)
+	sharedIncludedNodes := optimization.NewSharedIncludedNodes()
+	res, err := optimization.OptimizeBooleanNodes(ctx, node, sharedIncludedNodes)
+	require.NoError(t, err)
+	node, err = expr.ParseExpression(`OR(INCLUDE A, count(*) > 0)`)
+	require.NoError(t, err)
+	res2, err := optimization.OptimizeBooleanNodes(ctx, node, sharedIncludedNodes)
+	require.NoError(t, err)
+
+	require.IsType(t, &expr.BooleanNode{}, res)
+	bnode := res.(*expr.BooleanNode)
+	assert.Equal(t, 4, len(bnode.Args))
+	assert.Equal(t, "NOT true", bnode.Args[0].String())
+	assert.Equal(t, "city == \"Peoria, IL\"", bnode.Args[1].String())
+	assert.Equal(t, "zip IN (1, 2, 3)", bnode.Args[2].String())
+	require.Equal(t, "INCLUDE A", bnode.Args[3].String())
+	require.IsType(t, &expr.IncludeNode{}, bnode.Args[3])
+	inode := bnode.Args[3].(*expr.IncludeNode)
+	require.IsType(t, &expr.BooleanNode{}, inode.ExprNode)
+	bnode = inode.ExprNode.(*expr.BooleanNode)
+	assert.Equal(t, 2, len(bnode.Args))
+	assert.Equal(t, "*", bnode.Args[0].String())
+	require.IsType(t, &expr.BooleanNode{}, bnode.Args[1])
+	bnode = bnode.Args[1].(*expr.BooleanNode)
+	assert.Equal(t, 2, len(bnode.Args))
+	assert.Equal(t, "city == \"Peoria, IL\"", bnode.Args[0].String())
+	assert.Equal(t, "zip BETWEEN 1 AND 3", bnode.Args[1].String())
+
+	require.IsType(t, &expr.BooleanNode{}, res2)
+	bnode = res2.(*expr.BooleanNode)
+	assert.Equal(t, 2, len(bnode.Args))
+	assert.Equal(t, "count(*) > 0", bnode.Args[0].String())
+	require.Equal(t, "INCLUDE A", bnode.Args[1].String())
+	require.IsType(t, &expr.IncludeNode{}, bnode.Args[1])
+	assert.Same(t, res2.(*expr.BooleanNode).Args[1].(*expr.IncludeNode).ExprNode, res.(*expr.BooleanNode).Args[3].(*expr.IncludeNode).ExprNode, "should be shared via sharedIncludedNodes")
+}


### PR DESCRIPTION
This should make evaluation of boolean nodes faster on average. Assuming that each argument in a boolean node has the same probability to cause a short-circuit, it is better to evaluate the arguments that are faster to evaluate first.
See https://github.com/lytics/lio/compare/develop...use-ast-optimization for usage