### PR TITLE
Add copy method

### DIFF
--- a/expr/include.go
+++ b/expr/include.go
@@ -26,12 +26,10 @@ func InlineIncludes(ctx Includer, n Node) (Node, error) {
 	return doInlineIncludes(ctx, n, 0)
 }
 func doInlineIncludes(ctx Includer, n Node, depth int) (Node, error) {
-	// We need to make a copy, so we lazily use the To/From pb
 	// We need the copy because we are going to mutate this node
 	// but AST is assumed to be immuteable, and shared, since we are breaking
 	// this contract we copy
-	npb := n.NodePb()
-	newNode := NodeFromNodePb(npb)
+	newNode := n.Copy()
 	return inlineIncludesDepth(ctx, newNode, depth)
 }
 func inlineIncludesDepth(ctx Includer, arg Node, depth int) (Node, error) {

--- a/expr/include_test.go
+++ b/expr/include_test.go
@@ -103,8 +103,8 @@ func TestInlineIncludes(t *testing.T) {
 	}
 	tests = []incTest{
 		{
-			in:  `AND ( lastvisit_ts < "now-3d", NOT INCLUDE nested_includes_yoda )`,
-			out: `AND ( lastvisit_ts < "now-3d", NOT AND ( planet == "Dagobah", name == "Yoda" ) )`,
+			in:  `NOT AND ( lastvisit_ts < "now-3d", NOT INCLUDE nested_includes_yoda )`,
+			out: `NOT AND ( lastvisit_ts < "now-3d", NOT AND ( planet == "Dagobah", name == "Yoda" ) )`,
 		},
 	}
 	for _, tc := range tests {

--- a/expr/node.go
+++ b/expr/node.go
@@ -675,6 +675,18 @@ func (m *FuncNode) Equal(n Node) bool {
 		if len(m.Args) != len(nt.Args) {
 			return false
 		}
+		if m.Eval == nil && nt.Eval != nil {
+			return false
+		}
+		if m.Eval != nil && nt.Eval == nil {
+			return false
+		}
+		if m.F.CustomFunc == nil && nt.F.CustomFunc != nil {
+			return false
+		}
+		if m.F.CustomFunc != nil && nt.F.CustomFunc == nil {
+			return false
+		}
 		for i, arg := range nt.Args {
 			if !arg.Equal(m.Args[i]) {
 				return false

--- a/expr/node.go
+++ b/expr/node.go
@@ -93,6 +93,9 @@ type (
 
 		// NodeType the String, Identity, etc
 		NodeType() string
+
+		// Copy makes a deep copy of this node
+		Copy() Node
 	}
 
 	// NodeArgs is an interface for nodes which have child arguments
@@ -530,6 +533,14 @@ func NewFuncNode(name string, f Func) *FuncNode {
 func (m *FuncNode) append(arg Node) {
 	m.Args = append(m.Args, arg)
 }
+func (m *FuncNode) Copy() Node {
+	n := *m
+	n.Args = make([]Node, len(m.Args))
+	for i, arg := range m.Args {
+		n.Args[i] = arg.Copy()
+	}
+	return &n
+}
 func (m *FuncNode) NodeType() string { return "Func" }
 func (m *FuncNode) String() string {
 	w := NewDefaultWriter()
@@ -723,6 +734,10 @@ func (m *NumberNode) NodeType() string             { return "Number" }
 func (n *NumberNode) String() string               { return n.Text }
 func (m *NumberNode) WriteDialect(w DialectWriter) { w.WriteNumber(m.Text) }
 func (m *NumberNode) Validate() error              { return nil }
+func (m *NumberNode) Copy() Node {
+	n := *m
+	return &n
+}
 func (m *NumberNode) NodePb() *NodePb {
 	n := &NumberNodePb{}
 	n.Text = m.Text
@@ -797,6 +812,10 @@ func (m *StringNode) String() string {
 	}
 	return fmt.Sprintf("%q", m.Text)
 }
+func (m *StringNode) Copy() Node {
+	n := *m
+	return &n
+}
 func (m *StringNode) WriteDialect(w DialectWriter) {
 	w.WriteLiteral(m.Text)
 }
@@ -857,6 +876,10 @@ func (m *StringNode) Equal(n Node) bool {
 
 func NewValueNode(val value.Value) *ValueNode {
 	return &ValueNode{Value: val, rv: reflect.ValueOf(val)}
+}
+func (m *ValueNode) Copy() Node {
+	n := *m
+	return &n
 }
 func (m *ValueNode) NodeType() string { return "Value" }
 func (m *ValueNode) IsArray() bool {
@@ -1005,6 +1028,10 @@ func (m *IdentityNode) load() {
 	} else {
 		m.left, m.right, _ = LeftRight(m.Text)
 	}
+}
+func (m *IdentityNode) Copy() Node {
+	n := *m
+	return &n
 }
 func (m *IdentityNode) NodeType() string { return "Identity" }
 func (m *IdentityNode) String() string {
@@ -1157,6 +1184,10 @@ func (m *IdentityNode) LeftRight() (string, string, bool) {
 func NewNull(operator lex.Token) *NullNode {
 	return &NullNode{}
 }
+func (m *NullNode) Copy() Node {
+	n := *m
+	return &n
+}
 func (m *NullNode) NodeType() string { return "Null" }
 func (m *NullNode) String() string   { return "NULL" }
 func (m *NullNode) WriteDialect(w DialectWriter) {
@@ -1217,6 +1248,14 @@ unary_op   = "+" | "-" | "!" | "^" | "*" | "&" | "<-" .
 func NewBinaryNode(operator lex.Token, lhArg, rhArg Node) *BinaryNode {
 	//u.Debugf("NewBinaryNode: %v %v %v", lhArg, operator, rhArg)
 	return &BinaryNode{Args: []Node{lhArg, rhArg}, Operator: operator}
+}
+func (m *BinaryNode) Copy() Node {
+	n := *m
+	n.Args = make([]Node, len(m.Args))
+	for i, arg := range m.Args {
+		n.Args[i] = arg.Copy()
+	}
+	return &n
 }
 func (m *BinaryNode) NodeType() string { return "Binary" }
 func (m *BinaryNode) String() string {
@@ -1416,6 +1455,14 @@ func NewBooleanNode(operator lex.Token, args ...Node) *BooleanNode {
 	//u.Debugf("NewBinaryNode: %v %v %v", lhArg, operator, rhArg)
 	return &BooleanNode{Args: args, Operator: operator}
 }
+func (m *BooleanNode) Copy() Node {
+	n := *m
+	n.Args = make([]Node, len(m.Args))
+	for i, arg := range m.Args {
+		n.Args[i] = arg.Copy()
+	}
+	return &n
+}
 func (m *BooleanNode) NodeType() string { return "Boolean" }
 func (m *BooleanNode) ReverseNegation() bool {
 	m.negated = !m.negated
@@ -1564,6 +1611,14 @@ func (m *BooleanNode) Equal(n Node) bool {
 func NewTriNode(operator lex.Token, arg1, arg2, arg3 Node) *TriNode {
 	return &TriNode{Args: []Node{arg1, arg2, arg3}, Operator: operator}
 }
+func (m *TriNode) Copy() Node {
+	n := *m
+	n.Args = make([]Node, len(m.Args))
+	for i, arg := range m.Args {
+		n.Args[i] = arg.Copy()
+	}
+	return &n
+}
 func (m *TriNode) NodeType() string { return "Ternary" }
 func (m *TriNode) ReverseNegation() bool {
 	m.negated = !m.negated
@@ -1711,6 +1766,11 @@ func NewUnary(operator lex.Token, arg Node) Node {
 
 	return &UnaryNode{Arg: arg, Operator: operator}
 }
+func (m *UnaryNode) Copy() Node {
+	n := *m
+	n.Arg = m.Arg.Copy()
+	return &n
+}
 func (m *UnaryNode) NodeType() string { return "Unary" }
 func (m *UnaryNode) String() string {
 	w := NewDefaultWriter()
@@ -1822,6 +1882,13 @@ func (m *UnaryNode) Equal(n Node) bool {
 func NewInclude(operator lex.Token, id *IdentityNode) *IncludeNode {
 	return &IncludeNode{Identity: id, Operator: operator}
 }
+func (m *IncludeNode) Copy() Node {
+	n := *m
+	n.Identity = m.Identity.Copy().(*IdentityNode)
+	n.ExprNode = nil
+	n.inlineExpr = nil
+	return &n
+}
 func (m *IncludeNode) NodeType() string { return "Include" }
 func (m *IncludeNode) String() string {
 	w := NewDefaultWriter()
@@ -1932,6 +1999,15 @@ func NewArrayNode() *ArrayNode {
 }
 func NewArrayNodeArgs(args []Node) *ArrayNode {
 	return &ArrayNode{Args: args}
+}
+func (m *ArrayNode) Copy() Node {
+	n := *m
+	n.Args = make([]Node, len(m.Args))
+	for i, arg := range m.Args {
+		n.Args[i] = arg.Copy()
+	}
+	return &n
+
 }
 func (m *ArrayNode) NodeType() string { return "Array" }
 func (m *ArrayNode) String() string {

--- a/optimization/optimization.go
+++ b/optimization/optimization.go
@@ -57,38 +57,8 @@ func optimizeBooleanNodesDepth(ctx expr.Includer, arg expr.Node, depth int, shar
 		for i, node := range nodes {
 			n.Args[i] = node.node
 		}
-	case *expr.BinaryNode:
-		for _, narg := range n.Args {
-			subTreeResult, err := optimizeBooleanNodesDepth(ctx, narg, depth+1, sharedIncludedNodes)
-			if err != nil {
-				return 0, err
-			}
-			result += subTreeResult
-		}
-	case *expr.UnaryNode:
-		subTreeResult, err := optimizeBooleanNodesDepth(ctx, n.Arg, depth+1, sharedIncludedNodes)
-		if err != nil {
-			return 0, err
-		}
-		result += subTreeResult
-	case *expr.TriNode:
-		for _, narg := range n.Args {
-			subTreeResult, err := optimizeBooleanNodesDepth(ctx, narg, depth+1, sharedIncludedNodes)
-			if err != nil {
-				return 0, err
-			}
-			result += subTreeResult
-		}
-	case *expr.ArrayNode:
-		for _, narg := range n.Args {
-			subTreeResult, err := optimizeBooleanNodesDepth(ctx, narg, depth+1, sharedIncludedNodes)
-			if err != nil {
-				return 0, err
-			}
-			result += subTreeResult
-		}
-	case *expr.FuncNode:
-		for _, narg := range n.Args {
+	case expr.NodeArgs:
+		for _, narg := range n.ChildrenArgs() {
 			subTreeResult, err := optimizeBooleanNodesDepth(ctx, narg, depth+1, sharedIncludedNodes)
 			if err != nil {
 				return 0, err

--- a/optimization/optimization.go
+++ b/optimization/optimization.go
@@ -27,8 +27,7 @@ type nodeWithNumberOfChildren struct {
 // OptimizeBooleanNodes optimizes boolean nodes in the expression tree by sorting their arguments by number of children.
 // It returns an optimized deep-copy of the expression tree in order not to violate the immutability of expression trees.
 func OptimizeBooleanNodes(ctx expr.Includer, arg expr.Node, sharedIncludedNodes *SharedIncludedNodes) (expr.Node, error) {
-	npb := arg.NodePb()
-	newNode := expr.NodeFromNodePb(npb)
+	newNode := arg.Copy()
 	_, err := optimizeBooleanNodesDepth(ctx, newNode, 0, sharedIncludedNodes)
 	return newNode, err
 }
@@ -108,8 +107,7 @@ func optimizeBooleanNodesDepth(ctx expr.Includer, arg expr.Node, depth int, shar
 			if incExpr == nil {
 				return 0, expr.ErrIncludeNotFound
 			}
-			npb := incExpr.NodePb()
-			n.ExprNode = expr.NodeFromNodePb(npb)
+			n.ExprNode = incExpr.Copy()
 			subTreeResult, err := optimizeBooleanNodesDepth(ctx, n.ExprNode, depth+1, sharedIncludedNodes)
 			if err != nil {
 				return 0, err

--- a/optimization/optimization_test.go
+++ b/optimization/optimization_test.go
@@ -36,7 +36,7 @@ func (m *includectx) Include(name string) (expr.Node, error) {
 func TestOptimizeBooleanNodes(t *testing.T) {
 	nc := datasource.NewNestedContextReader([]expr.ContextReader{}, time.Now())
 	ctx := newIncluderCtx(nc,
-		`FILTER AND (
+		`FILTER NOT AND (
 						OR (
 							zip BETWEEN 1 AND 3
 							city == "Peoria, IL"
@@ -65,6 +65,7 @@ func TestOptimizeBooleanNodes(t *testing.T) {
 	inode := bnode.Args[3].(*expr.IncludeNode)
 	require.IsType(t, &expr.BooleanNode{}, inode.ExprNode)
 	bnode = inode.ExprNode.(*expr.BooleanNode)
+	assert.True(t, bnode.Negated())
 	assert.Equal(t, 2, len(bnode.Args))
 	assert.Equal(t, "*", bnode.Args[0].String())
 	require.IsType(t, &expr.BooleanNode{}, bnode.Args[1])


### PR DESCRIPTION
Converting to the Protobuf struct and back loses the negated property (for boolean nodes at least). This adds a copy method for expr nodes. This should also fix InlineIncludes().