### PR TITLE
fix(vm): treat a present-but-empty collection as not EXISTS

### DIFF
--- a/vm/vm.go
+++ b/vm/vm.go
@@ -849,6 +849,14 @@ func walkUnary(ctx expr.EvalContext, includer expr.Includer, node *expr.UnaryNod
 		switch a.(type) {
 		case nil, value.NilValue:
 			return value.NewBoolValue(false), true
+		// A present-but-empty collection does not "exist": an empty list/map
+		// carries no value, so EXISTS is false (matches Elasticsearch, which
+		// does not index empty arrays). Scalars (incl. empty string) are left
+		// as present.
+		case value.StringsValue, value.SliceValue, value.ByteSliceValue,
+			value.MapValue, value.MapStringValue, value.MapIntValue,
+			value.MapNumberValue, value.MapTimeValue, value.MapBoolValue:
+			return value.NewBoolValue(!a.Nil()), true
 		}
 		return value.NewBoolValue(true), true
 	default:

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -50,17 +50,19 @@ var (
 	//  and be available to the VM runtime for evaluation by using
 	//  key's such as "int5" or "user_id"
 	msgContext = datasource.NewContextMap(map[string]any{
-		"int5":    value.NewIntValue(5),
-		"str5":    value.NewStringValue("5"),
-		"created": value.NewTimeValue(tcreated),
-		"bvalt":   value.NewBoolValue(true),
-		"bvalf":   value.NewBoolValue(false),
-		"user_id": value.NewStringValue("abc"),
-		"urls":    value.NewStringsValue([]string{"abc", "123"}),
-		"hits":    value.NewMapIntValue(map[string]int64{"google.com": 5, "bing.com": 1}),
-		"email":     value.NewStringValue("bob@bob.com"),
-		"empty_str": value.NewStringValue(""),
-		"mt":      value.NewMapTimeValue(map[string]time.Time{"event0": t0, "event1": t1}),
+		"int5":       value.NewIntValue(5),
+		"str5":       value.NewStringValue("5"),
+		"created":    value.NewTimeValue(tcreated),
+		"bvalt":      value.NewBoolValue(true),
+		"bvalf":      value.NewBoolValue(false),
+		"user_id":    value.NewStringValue("abc"),
+		"urls":       value.NewStringsValue([]string{"abc", "123"}),
+		"hits":       value.NewMapIntValue(map[string]int64{"google.com": 5, "bing.com": 1}),
+		"email":      value.NewStringValue("bob@bob.com"),
+		"empty_str":  value.NewStringValue(""),
+		"empty_strs": value.NewStringsValue([]string{}),
+		"empty_map":  value.NewMapIntValue(map[string]int64{}),
+		"mt":         value.NewMapTimeValue(map[string]time.Time{"event0": t0, "event1": t1}),
 	}, true)
 
 	// list of tests
@@ -230,6 +232,16 @@ var (
 		vmt(`EXISTS bvalt`, true, noError),
 		vmt(`EXISTS bvalf`, true, noError),
 		vmt(`EXISTS toint(not_a_field)`, false, noError),
+
+		// A present-but-empty collection does not exist; a populated one does.
+		vmt(`EXISTS urls`, true, noError),
+		vmt(`EXISTS empty_strs`, false, noError),
+		vmt(`NOT EXISTS empty_strs`, true, noError),
+		vmt(`EXISTS hits`, true, noError),
+		vmt(`EXISTS empty_map`, false, noError),
+		vmt(`NOT EXISTS empty_map`, true, noError),
+		// Scalars are unaffected: an empty string is still present.
+		vmt(`EXISTS empty_str`, true, noError),
 
 		// TODO:  support () wrapping parts of binary expression
 		vmt(`6 == (5 + 1)`, true, noError),


### PR DESCRIPTION
## What

`EXISTS <field>` in the VM returned `true` for any present value that was not `nil`/`NilValue`. A present-but-empty collection (an empty `StringsValue`, `SliceValue`, or any `Map*Value`) is not nil, so it evaluated as `EXISTS = true` / `NOT EXISTS = false`.

Elasticsearch does not index empty arrays, so the esgen path treats a present empty array as **not existing** (`NOT EXISTS = true`). The two engines therefore disagreed on `NOT EXISTS <collection>` whenever a field was persisted as a present empty value.

This scopes the VM's `EXISTS` to return `false` for empty collections, matching ES.

| field state | before | after |
|---|---|---|
| absent | EXISTS=false | EXISTS=false |
| present, empty `[]` / `{}` | **EXISTS=true** | **EXISTS=false** |
| present, populated | EXISTS=true | EXISTS=true |

`NOT EXISTS` is the negation, so it flips correspondingly for the empty case.

## Why it matters

In a downstream CDP, an ES-backed segment scan selected members where `NOT EXISTS <field>` was true (field stored as empty `[]`), but the VM re-eval on the same entities returned "not a member" and dropped them — so a whole audience matched in the UI/backfill yet produced nothing on export. Verified against a real 108k-member audience: 100% had the field present-but-empty.

## Scope / blast radius

- **Collections only.** Change is limited to the collection value types (`StringsValue`, `SliceValue`, `ByteSliceValue`, and the `Map*Value` family). Scalars are untouched — a present empty string (`EXISTS ""`) is still `true`, as pinned by the existing `empty_str` test.
- Behavior changes for any filter using `EXISTS`/`NOT EXISTS` on a collection field that can be present-but-empty. This is the intended correction (align VM with ES).

## Tests

- Added cases in `vm/vm_test.go`: `EXISTS empty_strs` → false, `NOT EXISTS empty_strs` → true, `EXISTS empty_map` → false, plus populated (`urls`, `hits`) → true and scalar `empty_str` → true (unchanged).
- Full module `go test ./...` passes; no existing test relied on the old behavior.
- Pinning verified via `-overlay`: reverting the logic makes `EXISTS empty_strs` fail with `true != false`, confirming the new tests actually exercise the change.